### PR TITLE
Add example usage for SPFService and enhance SPFRecord structure

### DIFF
--- a/src/services/__tests__/spf.service.test.ts
+++ b/src/services/__tests__/spf.service.test.ts
@@ -14,7 +14,7 @@ describe('SPFService', () => {
   describe('getSPFRecord', () => {
     it('should return parsed SPF record for valid domain', async () => {
       // Mock fetch response
-      vi.spyOn(window, 'fetch').mockResolvedValue({
+      const mockFetch = vi.fn().mockResolvedValue({
         ok: true,
         json: () => Promise.resolve({
           Status: 0,
@@ -26,6 +26,7 @@ describe('SPFService', () => {
           }]
         })
       } as Response);
+      vi.stubGlobal('fetch', mockFetch);
 
       const result = await spfService.getSPFRecord(mockDomain);
 
@@ -50,20 +51,22 @@ describe('SPFService', () => {
     });
 
     it('should return null when no SPF record is found', async () => {
-      vi.spyOn(window, 'fetch').mockResolvedValue({
+      const mockFetch = vi.fn().mockResolvedValue({
         ok: true,
         json: () => Promise.resolve({
           Status: 0,
           Answer: []
         })
       } as Response);
+      vi.stubGlobal('fetch', mockFetch);
 
       const result = await spfService.getSPFRecord(mockDomain);
       expect(result).toBeNull();
     });
 
     it('should return null when fetch fails', async () => {
-      vi.spyOn(window, 'fetch').mockRejectedValue(new Error('Network error'));
+      const mockFetch = vi.fn().mockRejectedValue(new Error('Network error'));
+      vi.stubGlobal('fetch', mockFetch);
 
       const result = await spfService.getSPFRecord(mockDomain);
       expect(result).toBeNull();
@@ -71,7 +74,7 @@ describe('SPFService', () => {
 
     it('should handle SPF record with modifiers', async () => {
       const recordWithModifier = '"v=spf1 include:_spf.google.com redirect=_spf.example.com"';
-      vi.spyOn(window, 'fetch').mockResolvedValue({
+      const mockFetch = vi.fn().mockResolvedValue({
         ok: true,
         json: () => Promise.resolve({
           Status: 0,
@@ -83,6 +86,7 @@ describe('SPFService', () => {
           }]
         })
       } as Response);
+      vi.stubGlobal('fetch', mockFetch);
 
       const result = await spfService.getSPFRecord(mockDomain);
 
@@ -93,6 +97,108 @@ describe('SPFService', () => {
         type: 'redirect',
         value: '_spf.example.com'
       });
+    });
+
+    it('should track recursive processing counts for redirects and includes', async () => {
+      // Mock the main domain response
+      const mockFetch = vi.fn()
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve({
+            Status: 0,
+            Answer: [{
+              name: mockDomain,
+              type: 16,
+              TTL: 300,
+              data: '"v=spf1 include:_spf.google.com redirect=redirected.com"'
+            }]
+          })
+        } as Response)
+        // Mock the redirected domain response
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve({
+            Status: 0,
+            Answer: [{
+              name: 'redirected.com',
+              type: 16,
+              TTL: 300,
+              data: '"v=spf1 include:_spf.microsoft.com ~all"'
+            }]
+          })
+        } as Response)
+        // Mock the included domain response (from main domain)
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve({
+            Status: 0,
+            Answer: [{
+              name: '_spf.google.com',
+              type: 16,
+              TTL: 300,
+              data: '"v=spf1 ip4:192.168.0.1 ~all"'
+            }]
+          })
+        } as Response)
+        // Mock the redirected domain's included domain response
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve({
+            Status: 0,
+            Answer: [{
+              name: '_spf.microsoft.com',
+              type: 16,
+              TTL: 300,
+              data: '"v=spf1 ip4:10.0.0.1 ~all"'
+            }]
+          })
+        } as Response);
+      vi.stubGlobal('fetch', mockFetch);
+
+      const result = await spfService.getSPFRecord(mockDomain);
+
+      expect(result).not.toBeNull();
+      expect(result?.processedRedirects).toBe(1); // One redirect from main domain
+      expect(result?.processedIncludes).toBe(2); // One include from main domain + one from redirected domain
+      expect(result?.redirects).toHaveLength(1);
+      expect(result?.includes).toHaveLength(1); // Only includes from the main domain are tracked
+    });
+  });
+
+  describe('getSPFRecordForDomain', () => {
+    it('should return formatted response with recursive processing counts', async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({
+          Status: 0,
+          Answer: [{
+            name: mockDomain,
+            type: 16,
+            TTL: 300,
+            data: '"v=spf1 ip4:192.168.0.1 ~all"'
+          }]
+        })
+      } as Response);
+      vi.stubGlobal('fetch', mockFetch);
+
+      const result = await spfService.getSPFRecordForDomain(mockDomain);
+
+      expect(spfService.isSuccessResponse(result)).toBe(true);
+      if (spfService.isSuccessResponse(result)) {
+        expect(result.summary.processedRedirects).toBe(0);
+        expect(result.summary.processedIncludes).toBe(0); // No includes in this record
+        expect(result.summary.totalMechanisms).toBe(2);
+        expect(result.summary.redirectCount).toBe(0);
+      }
+    });
+
+    it('should handle domain validation errors', async () => {
+      const result = await spfService.getSPFRecordForDomain('');
+
+      expect(spfService.isErrorResponse(result)).toBe(true);
+      if (spfService.isErrorResponse(result)) {
+        expect(result.error).toBe('Domain parameter is required');
+      }
     });
   });
 }); 

--- a/src/services/example-usage.ts
+++ b/src/services/example-usage.ts
@@ -143,4 +143,58 @@ export class ExampleController {
     // Return successful response
     return { status: 200, data: result };
   }
-} 
+}
+
+/**
+ * Example usage of SPFService with recursive processing counts
+ */
+async function exampleUsage() {
+  const spfService = new SPFService();
+  
+  // Example domains that might have redirects and includes
+  const testDomains = [
+    'google.com',
+    'microsoft.com', 
+    'github.com',
+    'example.com'
+  ];
+  
+  for (const domain of testDomains) {
+    console.log(`\n🔍 Testing domain: ${domain}`);
+    
+    try {
+      const result = await spfService.getSPFRecordForDomain(domain);
+      
+      if (spfService.isSuccessResponse(result)) {
+        console.log(`✅ Success for ${domain}:`);
+        console.log(`   📊 Summary:`);
+        console.log(`      - Total mechanisms: ${result.summary.totalMechanisms}`);
+        console.log(`      - Total modifiers: ${result.summary.totalModifiers}`);
+        console.log(`      - Redirect count: ${result.summary.redirectCount}`);
+        console.log(`      - Processed redirects: ${result.summary.processedRedirects}`);
+        console.log(`      - Processed includes: ${result.summary.processedIncludes}`);
+        console.log(`      - Has redirects: ${result.summary.hasRedirects}`);
+        
+        if (result.redirects && result.redirects.length > 0) {
+          console.log(`   🔄 Redirects:`);
+          result.redirects.forEach((redirect, index) => {
+            console.log(`      ${index + 1}. ${redirect.from} -> ${redirect.to}`);
+          });
+        }
+        
+        if (result.includes && result.includes.length > 0) {
+          console.log(`   📋 Includes:`);
+          result.includes.forEach((include, index) => {
+            console.log(`      ${index + 1}. ${include.domain} (${include.mechanisms.length} mechanisms)`);
+          });
+        }
+      } else {
+        console.log(`❌ Error for ${domain}: ${result.error}`);
+      }
+    } catch (error) {
+      console.error(`💥 Exception for ${domain}:`, error);
+    }
+  }
+}
+
+export { exampleUsage }; 

--- a/src/services/spf.service.ts
+++ b/src/services/spf.service.ts
@@ -26,6 +26,19 @@ export interface SPFRecord {
     value: string;
   }[];
   redirects?: SPFRedirect[];
+  includes?: {
+    domain: string;
+    record: string;
+    mechanisms: {
+      type: string;
+      value: string;
+      qualifier?: string;
+    }[];
+    modifiers: {
+      type: string;
+      value: string;
+    }[];
+  }[];
   redirectedRecord?: {
     raw: string;
     mechanisms: {
@@ -38,6 +51,9 @@ export interface SPFRecord {
       value: string;
     }[];
   };
+  // Tracking counts for recursive processing
+  processedRedirects?: number;
+  processedIncludes?: number;
 }
 
 export interface SPFResponse {
@@ -53,8 +69,11 @@ export interface SPFResponse {
     hasRedirectedRecord?: boolean;
     redirectedMechanisms?: number;
     redirectedModifiers?: number;
+    processedRedirects: number;
+    processedIncludes: number;
   };
   redirects?: SPFRedirect[];
+  includes?: SPFRecord['includes'];
   hasRedirects?: boolean;
   finalDomain?: string;
   redirectedRecord?: {
@@ -149,7 +168,9 @@ export class SPFService {
         totalMechanisms: spfRecord.mechanisms.length,
         totalModifiers: spfRecord.modifiers.length,
         hasRedirects: false,
-        redirectCount: 0
+        redirectCount: 0,
+        processedRedirects: spfRecord.processedRedirects || 0,
+        processedIncludes: spfRecord.processedIncludes || 0
       },
       metadata: {
         timestamp: new Date().toISOString(),
@@ -185,6 +206,11 @@ export class SPFService {
       response.summary.hasRedirects = false;
       response.summary.redirectCount = 0;
       response.summary.hasRedirectedRecord = false;
+    }
+
+    // Handle includes information if present
+    if (spfRecord.includes && spfRecord.includes.length > 0) {
+      response.includes = spfRecord.includes;
     }
 
     return response;
@@ -350,12 +376,20 @@ export class SPFService {
     // Parse the SPF record into structured components
     const spfRecord = this.parseSPFRecord(rawRecord);
     const redirects: SPFRedirect[] = [];
+    const includes: SPFRecord['includes'] = [];
+    
+    // Initialize counters for recursive processing
+    let totalProcessedRedirects = 0;
+    let totalProcessedIncludes = 0;
 
     // Check for redirect modifier in the SPF record
     const redirectModifier = spfRecord.modifiers.find(mod => mod.type === 'redirect');
     if (redirectModifier) {
       const redirectDomain = redirectModifier.value;
       console.log(`🔄 Found redirect modifier: ${domain} -> ${redirectDomain}`);
+      
+      // Increment redirect counter
+      totalProcessedRedirects++;
       
       // Add current redirect to the tracking list
       redirects.push({
@@ -371,6 +405,10 @@ export class SPFService {
       
       if (redirectedRecord) {
         console.log(`✅ Successfully retrieved redirected record from: ${redirectDomain}`);
+        
+        // Add counts from redirected record
+        totalProcessedRedirects += redirectedRecord.processedRedirects || 0;
+        totalProcessedIncludes += redirectedRecord.processedIncludes || 0;
         
         // Merge any redirects from the redirected record
         if (redirectedRecord.redirects) {
@@ -388,14 +426,18 @@ export class SPFService {
               raw: redirectedRecord.raw,
               mechanisms: redirectedRecord.mechanisms,
               modifiers: redirectedRecord.modifiers
-            }
+            },
+            processedRedirects: totalProcessedRedirects,
+            processedIncludes: totalProcessedIncludes
           };
         } else {
           // Return the redirected record with updated redirect chain
           console.log(`📤 Returning redirected record with ${redirects.length} redirects in chain`);
           return {
             ...redirectedRecord,
-            redirects
+            redirects,
+            processedRedirects: totalProcessedRedirects,
+            processedIncludes: totalProcessedIncludes
           };
         }
       } else {
@@ -410,31 +452,54 @@ export class SPFService {
         const includeDomain = mechanism.value;
         console.log(`📋 Processing include mechanism: ${includeDomain}`);
         
+        // Increment include counter
+        totalProcessedIncludes++;
+        
         const includeRecord = await this.getSPFRecord(includeDomain, new Set([...visitedDomains]), false);
         
-        if (includeRecord && includeRecord.redirects) {
-          redirects.push(...includeRecord.redirects);
-          console.log(`📝 Added ${includeRecord.redirects.length} redirects from include: ${includeDomain}`);
+        if (includeRecord) {
+          // Add counts from included record
+          totalProcessedRedirects += includeRecord.processedRedirects || 0;
+          totalProcessedIncludes += includeRecord.processedIncludes || 0;
+          
+          // Add include to tracking list
+          includes.push({
+            domain: includeDomain,
+            record: includeRecord.raw,
+            mechanisms: includeRecord.mechanisms,
+            modifiers: includeRecord.modifiers
+          });
+          
+          if (includeRecord.redirects) {
+            redirects.push(...includeRecord.redirects);
+            console.log(`📝 Added ${includeRecord.redirects.length} redirects from include: ${includeDomain}`);
+          }
         }
       }
     }
 
     // If this is the initial call and we have redirects from includes, preserve the original record
-    if (isInitialCall && redirects.length > 0) {
-      console.log(`💾 Preserving original record (has ${redirects.length} redirects from includes)`);
+    if (isInitialCall && (redirects.length > 0 || includes.length > 0)) {
+      console.log(`💾 Preserving original record (has ${redirects.length} redirects, ${includes.length} includes from processing)`);
       return {
         ...spfRecord,
-        redirects: redirects.length > 0 ? redirects : undefined
+        redirects: redirects.length > 0 ? redirects : undefined,
+        includes: includes.length > 0 ? includes : undefined,
+        processedRedirects: totalProcessedRedirects,
+        processedIncludes: totalProcessedIncludes
       };
     }
 
     // Return the final result
     const result = {
       ...spfRecord,
-      redirects: redirects.length > 0 ? redirects : undefined
+      redirects: redirects.length > 0 ? redirects : undefined,
+      includes: includes.length > 0 ? includes : undefined,
+      processedRedirects: totalProcessedRedirects,
+      processedIncludes: totalProcessedIncludes
     };
     
-    console.log(`✅ Final SPF record for ${domain}: ${redirects.length} redirects, ${spfRecord.mechanisms.length} mechanisms`);
+    console.log(`✅ Final SPF record for ${domain}: ${redirects.length} redirects, ${includes.length} includes, ${totalProcessedRedirects} total processed redirects, ${totalProcessedIncludes} total processed includes`);
     return result;
   }
 


### PR DESCRIPTION
- Introduced `exampleUsage` function demonstrating recursive processing of SPF records, including handling of redirects and includes.
- Updated `SPFRecord` interface to include `includes` and processing counts for redirects and includes.
- Enhanced `SPFService` methods to track and return counts of processed redirects and includes.
- Added tests to verify recursive processing counts for redirects and includes in `SPFService`.